### PR TITLE
chore: Dockerfile and docker-compose for Streamlit app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Entornos virtuales
+.venv/
+venv/
+__pycache__/
+*.pyc
+*.pyo
+
+# Git
+.git/
+.gitignore
+
+# Notebooks y datos de desarrollo
+notebooks/
+data/
+*.ipynb
+*.ipynb_checkpoints
+
+# Modelos que no van a producción
+models/optimized_model.pkl
+models/best_baseline_pipeline.pkl
+models/cv_results.csv
+
+# Variables de entorno reales (nunca al contenedor)
+.env
+
+# Miscelánea
+*.md
+tests/
+.pytest_cache/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SUPABASE_URL=https://tu-proyecto.supabase.co
+SUPABASE_KEY=tu-anon-key-aqui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+
+services:
+  streamlit:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    container_name: pet_adoption_app
+    ports:
+      - "8501:8501"
+    env_file:
+      - .env                        # tus compañeras solo rellenan esto
+    environment:
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_KEY=${SUPABASE_KEY}
+    volumes:
+      # Solo en desarrollo local: recarga cambios sin rebuild
+      - ./src/app/streamlit_app.py:/app/src/app/streamlit_app.py
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8501/_stcore/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+# docker/Dockerfile
+FROM python:3.11-slim
+
+# Variables de entorno para Python
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Instalar uv
+RUN pip install uv
+
+# Copiar ficheros de dependencias primero (aprovecha caché de Docker)
+COPY pyproject.toml uv.lock ./
+
+# Instalar dependencias con uv
+RUN uv sync --frozen --no-dev
+
+# Copiar el código de la app y el modelo
+COPY src/app/streamlit_app.py ./src/app/streamlit_app.py
+COPY models/best_model_XGBoost.pkl ./models/best_model_XGBoost.pkl
+
+# Puerto de Streamlit
+EXPOSE 8501
+
+# Healthcheck para docker-compose
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+    CMD curl -f http://localhost:8501/_stcore/health || exit 1
+
+# Comando de arranque
+CMD ["uv", "run", "streamlit", "run", "src/app/streamlit_app.py", \
+     "--server.port=8501", \
+     "--server.address=0.0.0.0", \
+     "--server.headless=true"]


### PR DESCRIPTION
## 📋 Resumen
Dockerización de la aplicación Streamlit de predicción de días en refugio.
Incluye Dockerfile, docker-compose.yml, .dockerignore y plantilla de 
variables de entorno. El contenedor está preparado para recibir la 
integración de Supabase sin necesidad de modificar Docker.

## ✅ Archivos incluidos

- `docker/Dockerfile` — imagen basada en python:3.11-slim con uv
- `docker-compose.yml` — orquestación del servicio con variables de entorno
- `.dockerignore` — excluye notebooks, datos, venv y archivos de desarrollo
- `.env.example` — plantilla de variables de entorno para Supabase

## 🐳 Qué hace cada archivo

### Dockerfile
- Base: `python:3.11-slim` (ligera, sin dependencias innecesarias)
- Gestor de paquetes: `uv` (consistente con el resto del proyecto)
- Solo copia lo necesario para producción:
  - `src/app/streamlit_app.py`
  - `models/best_model_XGBoost.pkl`
- Incluye healthcheck en `/stcore/health`
- Expone el puerto 8501

### docker-compose.yml
- Lee variables de entorno desde `.env`
- Variables preparadas para Supabase: `SUPABASE_URL` y `SUPABASE_KEY`
- Volume mount de `streamlit_app.py` para desarrollo local sin rebuild
- Restart policy: `unless-stopped`

### .dockerignore
Excluye explícitamente:
- `notebooks/` y `data/` — no necesarios en producción
- `.venv/` — las dependencias se instalan dentro del contenedor
- `models/optimized_model.pkl` y `models/best_baseline_pipeline.pkl` 
  — solo va a producción el modelo ganador (`best_model_XGBoost.pkl`)
- `.env` — nunca debe entrar en el contenedor

### .env.example
Plantilla con las variables necesarias. Cada desarrollador debe:
```bash
cp .env.example .env
# Rellenar con sus credenciales reales
```

## ▶️ Cómo ejecutar

### Build y run directo
```bash
docker build -f docker/Dockerfile -t pet_adoption_app .
docker run -p 8501:8501 pet_adoption_app
```

### Con docker-compose (recomendado)
```bash
# 1. Crear tu .env local
cp .env.example .env
# 2. Rellenar SUPABASE_URL y SUPABASE_KEY en .env
# 3. Lanzar
docker-compose up --build
```

La app estará disponible en http://localhost:8501

## 🔗 Preparado para integración de Supabase

El contenedor ya lee `SUPABASE_URL` y `SUPABASE_KEY` como variables 
de entorno. Cuando la integración de Supabase esté lista, solo hay 
que añadir en `streamlit_app.py`:
```python
import os
from supabase import create_client

SUPABASE_URL = os.getenv("SUPABASE_URL")
SUPABASE_KEY = os.getenv("SUPABASE_KEY")

if SUPABASE_URL and SUPABASE_KEY:
    supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
```

Y rellenar el `.env` con las credenciales reales.
**No es necesario modificar el Dockerfile ni el docker-compose.**

## ⚠️ Importante para todos los miembros del equipo

- **Nunca commitear el `.env`** — está en `.gitignore`
- Usar siempre `.env.example` como referencia
- Para desarrollo local sin Docker: `uv run streamlit run src/app/streamlit_app.py`
- Para producción: `docker-compose up --build`

## 🔗 Dependencias
- Depende de: #17 (modelo XGBoost serializado)
- Relacionado con: integración Supabase (próxima issue)
- Relacionado con: tests unitarios (próxima issue)

Close #34 #35 